### PR TITLE
Update babacloud_api_analysis.py

### DIFF
--- a/A package for post-processing of babacloud outputs /Utils/extractBabyCSV.m
+++ b/A package for post-processing of babacloud outputs /Utils/extractBabyCSV.m
@@ -1,0 +1,47 @@
+function [extractedCSV, babyID] = extractBabyCSV(zipFilename, tmp_folder)
+% extractBabyCSV extracts a CSV file matching the pattern
+%   '^\d+_Classifiers_result\.csv$'
+% from the given zip file, and returns the full path to the extracted file 
+% along with the baby ID (the digits at the start of the file name).
+%
+% Inputs:
+%   zipFilename - Full path to the ZIP file.
+%   tmp_folder  - Folder where the file will be extracted.
+%
+% Outputs:
+%   extractedCSV - Full path to the extracted CSV file.
+%   babyID       - Baby ID extracted from the file name.
+    
+    % Create Java File and ZipFile objects.
+    zipJavaFile = java.io.File(zipFilename);
+    zipFile = org.apache.tools.zip.ZipFile(zipJavaFile);
+
+    entryFound = false;
+    entries = zipFile.getEntries;
+    while entries.hasMoreElements()
+        entry = entries.nextElement();
+        entryName = char(entry.getName());
+        % Get only the file name (ignore any subdirectory paths).
+        [~, name, ext] = fileparts(entryName);
+        fileName = [name, ext];
+        % Match pattern: one or more digits followed by _Classifiers_result.csv
+        tokens = regexp(fileName, '^(\d+)_Classifiers_result\.csv$', 'tokens');
+        if ~isempty(tokens)
+            babyID = tokens{1}{1};
+            extractedCSV = fullfile(tmp_folder, fileName);
+            % Create the output directory if it does not exist.
+            parentDir = fileparts(extractedCSV);
+            if ~exist(parentDir, 'dir')
+                mkdir(parentDir);
+            end
+            % Extract the file using Java streams.
+            fileOutputStream = java.io.FileOutputStream(java.io.File(extractedCSV));
+            fileInputStream = zipFile.getInputStream(entry);
+            streamCopier = com.mathworks.mlwidgets.io.InterruptibleStreamCopier.getInterruptibleStreamCopier;
+            streamCopier.copyStream(fileInputStream, fileOutputStream);
+            fileOutputStream.close;
+            entryFound = true;
+            break;
+        end
+    end
+    zipFile.close;

--- a/A package for post-processing of babacloud outputs /Utils/readfromZIPfiles.m
+++ b/A package for post-processing of babacloud outputs /Utils/readfromZIPfiles.m
@@ -2,11 +2,11 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% Functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function [ZIPcontent] = readfromZIPfiles(to_its_zip, tmp_folder, SubjectID)
-% Extract information from ZIP file
-extractFile(to_its_zip,tmp_folder, [SubjectID '_Classifiers_result.csv']);
-M = readtable([tmp_folder SubjectID '_Classifiers_result.csv'],'Delimiter',{';'},'NumHeaderLines',0,'VariableNamingRule','preserve');
-delete([tmp_folder SubjectID '_Classifiers_result.csv'])
+function [ZIPcontent, babyID] = readfromZIPfiles(to_its_zip, tmp_folder)
+% Extract information from ZIP file using extractBabyCSV.
+[extractedCSV, babyID] = extractBabyCSV(to_its_zip, tmp_folder);
+M = readtable(extractedCSV, 'Delimiter', { ';' }, 'NumHeaderLines', 0, 'VariableNamingRule', 'preserve');
+delete(extractedCSV)
 
 f_seizure = find(strncmp(M{:,1},'Seizures',8));
 f_artifact = find(strncmp(M{:,1},'Artefacts',9));

--- a/A package for post-processing of babacloud outputs /readBABACloudAnalysisZip.m
+++ b/A package for post-processing of babacloud outputs /readBABACloudAnalysisZip.m
@@ -49,7 +49,9 @@ addpath(UtilPwd)
 BABACloudFiles = './output/'; % BABACloud analysis outputs, zip files
 tmpFolder = './tmp/'; % A folder to save temporary files
 saveto = './ZIPcontent/'; % Save extracted data into
-SubjectID = 'Anonymous'; % Babacloud API default is Anonymous
+% SubjectID is extracted from the results files.
+% This also allow multiple babyID in the same folder.
+% SubjectID = 'Anonymous'; % Babacloud API default is Anonymous
 
 % List ZIP files in the folder
 ZIPFiles = findZIPFiles(BABACloudFiles);
@@ -57,11 +59,11 @@ ZIPFiles = findZIPFiles(BABACloudFiles);
 % Main
 for i = 1:length(ZIPFiles)
     disp(['Pocessing: ' ZIPFiles{i}])
-    % This line reads and extracts all the results stored in the zip file
-    [analysesOuts] = readfromZIPfiles([BABACloudFiles ZIPFiles{i}], tmpFolder, SubjectID);
+    % Extracts data from the ZIP and retrieves the baby ID from the CSV filename.
+    [analysesOuts, babyID] = readfromZIPfiles([BABACloudFiles ZIPFiles{i}], tmpFolder);
 
     % Save the extracted information
-    save([saveto ZIPFiles{i}(1:end-19) '.mat'], 'analysesOuts')
+    save([saveto babyID '.mat'], 'analysesOuts')
 end
 
 rmpath(UtilPwd)

--- a/A package for post-processing of babacloud outputs /readBABACloudAnalysisZip.m
+++ b/A package for post-processing of babacloud outputs /readBABACloudAnalysisZip.m
@@ -62,8 +62,12 @@ for i = 1:length(ZIPFiles)
     % Extracts data from the ZIP and retrieves the baby ID from the CSV filename.
     [analysesOuts, babyID] = readfromZIPfiles([BABACloudFiles ZIPFiles{i}], tmpFolder);
 
-    % Save the extracted information
-    save([saveto babyID '.mat'], 'analysesOuts')
+    % Use the zip file name (without extension) as the output file name.
+    [~, zipBaseName, ~] = fileparts(ZIPFiles{i});
+    outputFile = fullfile(saveto, [zipBaseName '.mat']);
+    
+    % Save the extracted data
+    save(outputFile, 'analysesOuts')
 end
 
 rmpath(UtilPwd)

--- a/API for BSN Batch processing/babacloud_api_analysis.py
+++ b/API for BSN Batch processing/babacloud_api_analysis.py
@@ -23,7 +23,12 @@ url_analysisrun = "https://babacloud.fi/apiv1/analysisrun/"
 LINE_UP = '\033[1A'
 LINE_CLEAR = '\x1b[2K'
 
+def retry_if_connection_error(exception):
+    '''Return True if we should retry (in this case when it's an ConnectionError), False otherwise'''
+    return isinstance(exception, requests.exceptions.ConnectionError)
 
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_delete(url, id):
     if id == '':
         return False
@@ -31,7 +36,8 @@ def api_delete(url, id):
                                                           credentials.pw))
     return response.ok
 
-
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_get(url, id):
     response = requests.get(url + str(id) + '/', auth=(credentials.user,
                                                        credentials.pw))
@@ -59,7 +65,8 @@ def api_delete_all(id_raw, delete_subject=False):
 
     return output_ok
 
-
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_search(url, target_id, target_key, output_keys=None):
     try:
         response = requests.get(url, auth=(credentials.user, credentials.pw))
@@ -97,7 +104,8 @@ def api_search(url, target_id, target_key, output_keys=None):
     output.update({'found': found})
     return output
 
-
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_search_rawfile(fname, target_subject):
     target_bname = os.path.basename(fname)
     response = requests.get(url_rawfile, auth=(credentials.user,
@@ -123,7 +131,8 @@ def api_search_rawfile(fname, target_subject):
 
     return found, id
 
-
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_create_subject(url, target_id):
     print(f'   Creating new ID: {target_id}')
     m = MultipartEncoder(fields={'identifier': target_id})
@@ -177,10 +186,6 @@ def create_monitor_callback(m):
 
     return callback
 
-def retry_if_connection_error(exception):
-    '''Return True if we should retry (in this case when it's an ConnectionError), False otherwise'''
-    return isinstance(exception, requests.exceptions.ConnectionError)
-
 # Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
 @retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_upload_file(url, filename, id_num, org_num, modality, analysis, labels):
@@ -224,7 +229,8 @@ def api_upload_file(url, filename, id_num, org_num, modality, analysis, labels):
     print(f'\nUpload complete (id: {id_raw}) (elapsed time: {(time_stop-time_start):0.2f} s)')
     return id_raw
 
-
+# Retry on connection error; Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds.
+@retry(retry_on_exception=retry_if_connection_error, wait_exponential_multiplier=1000, wait_exponential_max=100000, stop_max_attempt_number=10)
 def api_download_result(result_url, target_dir='./'):
     response = requests.get(result_url, auth=(credentials.user,
                                               credentials.pw))

--- a/API for BSN Batch processing/babacloud_api_analysis.py
+++ b/API for BSN Batch processing/babacloud_api_analysis.py
@@ -166,7 +166,8 @@ def create_monitor_callback(m):
         # done = int(50 * progress/encoder_len)
         time_now = time.time()
         elapsed = time_now - time_start
-        speed = ((progress - _progress_prev) / (1024 * 1024)) / (time_now - _time_prev)
+        epsilon = 1e-6 # Avoid division by zero error when time_now == _time_prev
+        speed = ((progress - _progress_prev) / (1024 * 1024)) / ((time_now - _time_prev) + epsilon)
 
         _progress_prev = progress
         _time_prev = time_now


### PR DESCRIPTION
I added a small value, "epsilon," to the monitor callback as sometimes it can happen that time_now is equal to _time_prev, and this results in a division by zero error. Adding a very small value does not change the speed variable significantly but avoid the error. Alternatively, you can add `if time_now - _time_prev == 0`, but I think this is a more elegant solution. Your choice. :)